### PR TITLE
1password-wine: pre-install /wine/drive_c/1Password

### DIFF
--- a/1password-wine/Dockerfile
+++ b/1password-wine/Dockerfile
@@ -2,7 +2,15 @@
 # docker build -t geekylucas/1password-wine .
 #
 # To run:
-# docker run -it -v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=unix$DISPLAY -v $HOME/Dropbox/1Password.agilekeychain:/root/Dropbox/1Password.agilekeychain --net="host" --name 1password-wine geekylucas/1password-wine bash
+# docker run \
+#   -it \
+#   -v /tmp/.X11-unix:/tmp/.X11-unix \
+#   -e DISPLAY=unix$DISPLAY \
+#   -v "$HOME/Dropbox/1Password.agilekeychain:/wine/drive_c/users/root/My Documents/1Password.agilekeychain" \
+#   --net="host" \
+#   --name 1password-wine \
+#   geekylucas/1password-wine \
+#   bash
 #
 # To operate:
 # Use up arrow for handy commands
@@ -13,12 +21,29 @@
 FROM jess/wine
 MAINTAINER Lucas Chan <docker@lucaschan.com>
 
-ADD https://d13itkw33a7sus.cloudfront.net/dist/1P/win4/1Password-4.6.0.598.exe /usr/src/1Password-4.6.0.598.exe
+ENV WINEPREFIX=/wine
 
-RUN echo "wine /root/.wine/drive_c/Program\ Files/1Password\ 4/Agile1pAgent.exe" > /root/.bash_history
-RUN echo "wine /root/.wine/drive_c/Program\ Files/1Password\ 4/1Password.exe" >> /root/.bash_history
-RUN echo "wine /usr/src/1Password-4.6.0.598.exe" >> /root/.bash_history
+RUN \
+  apt-get update && \
+  apt-get install -y --no-install-recommends \
+    xauth \
+    xvfb \
+  && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD https://d13itkw33a7sus.cloudfront.net/dist/1P/win4/1Password-4.6.0.598.exe /usr/src/
+
+# Auto install 1Password using xvfb as null display.
+# WINEDLLOVERRIDES=mscoree=d to disable wine's mono install prompt.
+# wineserver -k to flush registry files to disk after install.
+RUN xvfb-run -a bash -c "\
+  WINEDLLOVERRIDES=mscoree=d wine /usr/src/1Password-4.6.0.598.exe /VERYSILENT /DIR=c:\1Password && \
+  grep -A4 Installation /wine/drive_c/1Password/1Password.InnoSetup.log.txt && \
+  /usr/lib/i386-linux-gnu/wine/bin/wineserver -k"
+
+RUN echo >/root/.bash_history "wine /wine/drive_c/1Password/Agile1pAgent.exe" && \
+  echo >>/root/.bash_history "wine /wine/drive_c/1Password/1Password.exe"
 
 EXPOSE 6258
 
-CMD [ "bash" ]
+CMD ["wine", "/wine/drive_c/1Password/1Password.exe"]


### PR DESCRIPTION
Install 1Password during build to `/wine/c_drive/1Password` using [Inno Setup](http://jrsoftware.org/ishelp/index.php?topic=setupcmdline)'s `/VERYSILENT` and `/DIR` switches, after changing `WINEPREFIX` from `/root/.wine` to `/wine`. Use [Xvfb](https://en.wikipedia.org/wiki/Xvfb) as a null display during unattended install.

Change the default `CMD` to run the 1Password GUI.

Comment suggests mounting `1Password.agilekeychain` within `/wine/drive_c/users/root/My Documents/` to be closer to where the file browser opens to.

Writing `.bash_history` squashed into a single image layer.

---

Hard earned lesson: Wine seems to defer writing registry changes to disk; if not shut down with `wineserver -k`, the `docker build` process hard-kills it before the `/wine/*.reg` files are created, leading to cryptic fatal error messages at 1Password startup.
